### PR TITLE
[#73] mod: parse_line_env.c: in range uint to double

### DIFF
--- a/src/scene/parse_line_env.c
+++ b/src/scene/parse_line_env.c
@@ -72,7 +72,7 @@ t_light_conf	parse_light(const char *line)
 	if (array_size(split) != 4)
 		exit_with_error(EXIT_PARSE_ERROR, "light: invalid format");
 	brightness = parse_double(split[2]);
-	if (!is_in_range_uint(brightness, 0, 1))
+	if (!is_in_range_double(brightness, 0, 1))
 		exit_with_error(EXIT_FAILURE, "light: invalid value");
 	conf.position = parse_vec3(split[1]);
 	conf.brightness = brightness;


### PR DESCRIPTION
## やったこと
- light: brightnessに-を入れた際にエラーを出す


## 参照
#73 